### PR TITLE
small modifications + overload print

### DIFF
--- a/src/OSmOSE/Dataset.py
+++ b/src/OSmOSE/Dataset.py
@@ -585,8 +585,8 @@ class Dataset:
         metadata = pd.read_csv(self.original_folder.joinpath("metadata.csv"))
         list_display_metadata = ['sr_origin','audio_file_count','start_date','end_date','audio_file_origin_duration'] # restrain metadata to a shorter list of fileds to be displayed
         joined_str=''
-        print('Metadata of',self.name,':')
+        print(f"Metadata of {self.name} :")         
         for key, value in zip(metadata.keys(), metadata.values[0]):
             if key in list_display_metadata:
-                joined_str+=("- {} : {} \n".format(key,value))
+                joined_str+=f"- {key} : {value} \n"
         return joined_str

--- a/src/OSmOSE/Dataset.py
+++ b/src/OSmOSE/Dataset.py
@@ -581,13 +581,12 @@ class Dataset:
 
         return self.original_folder
 
-    def print_metadata(self):
+    def __str__(self):
         metadata = pd.read_csv(self.original_folder.joinpath("metadata.csv"))
-        print(
-            "\n".join(
-                [
-                    f"{key}: {value}"
-                    for key, value in zip(metadata.keys(), metadata.values[0])
-                ]
-            )
-        )
+        list_display_metadata = ['sr_origin','audio_file_count','start_date','end_date','audio_file_origin_duration'] # restrain metadata to a shorter list of fileds to be displayed
+        joined_str=''
+        print('Metadata of',self.name,':')
+        for key, value in zip(metadata.keys(), metadata.values[0]):
+            if key in list_display_metadata:
+                joined_str+=("- {} : {} \n".format(key,value))
+        return joined_str

--- a/src/OSmOSE/Spectrogram.py
+++ b/src/OSmOSE/Spectrogram.py
@@ -108,7 +108,7 @@ class Spectrogram(Dataset):
             analysis_sheet = {}
             self.__analysis_file = False
             print(
-                "No valid processed/adjust_metadata.csv found and no parameters provided. All attributes will be None."
+                "No valid processed/adjust_metadata.csv found and no parameters provided -> all attributes are initialized to their default values. \n"
             )
 
         self.batch_number: int = batch_number
@@ -126,7 +126,7 @@ class Spectrogram(Dataset):
             analysis_sheet["overlap"][0] if "overlap" in analysis_sheet else None
         )
         self.__colormap: str = (
-            analysis_sheet["colormap"][0] if "colormap" in analysis_sheet else None
+            analysis_sheet["colormap"][0] if "colormap" in analysis_sheet else "viridis"
         )
         self.__zoom_level: int = (
             analysis_sheet["zoom_level"][0] if "zoom_level" in analysis_sheet else None
@@ -198,7 +198,7 @@ class Spectrogram(Dataset):
         self.__window_type: str = (
             analysis_sheet["window_type"][0]
             if "window_type" in analysis_sheet
-            else None
+            else "hamming"
         )
 
         self.__frequency_resolution: int = (


### PR DESCRIPTION
plus one question/recommendation : why not directly using the setter on variable definitions from 114 to 218 in Spectrogram.py ?

ie eg replacing self.__nfft  to self.nfft in :
 
        self.__nfft: int = (
            analysis_sheet["nfft"][0] if "nfft" in analysis_sheet else None
        )

[.....]

this will be necessary if we set tests on input values (eg nfft must be >0 or a multiple of 2^) that will have to be in their setters no ?